### PR TITLE
update: add ability to restrict lookback on film updates to avoid let…

### DIFF
--- a/LetterboxdSync/Configuration/Account.cs
+++ b/LetterboxdSync/Configuration/Account.cs
@@ -13,4 +13,8 @@ public class Account
     public bool Enable { get; set; }
 
     public bool SendFavorite { get; set; }
+
+    public bool EnableDateFilter { get; set; }
+
+    public int DateFilterDays { get; set; } = 7;
 }

--- a/LetterboxdSync/LetterboxdSyncTask.cs
+++ b/LetterboxdSync/LetterboxdSyncTask.cs
@@ -67,6 +67,17 @@ public class LetterboxdSyncTask : IScheduledTask
             if (lstMoviesPlayed.Count == 0)
                 continue;
 
+            // Apply date filtering if enabled
+            if (account.EnableDateFilter)
+            {
+                var cutoffDate = DateTime.UtcNow.AddDays(-account.DateFilterDays);
+                lstMoviesPlayed = lstMoviesPlayed.Where(movie =>
+                {
+                    var userItemData = _userDataManager.GetUserData(user, movie);
+                    return userItemData.LastPlayedDate.HasValue && userItemData.LastPlayedDate.Value >= cutoffDate;
+                }).ToList();
+            }
+
             var api = new LetterboxdApi();
             try
             {

--- a/LetterboxdSync/Web/configLetterboxd.html
+++ b/LetterboxdSync/Web/configLetterboxd.html
@@ -36,6 +36,19 @@
                         <div class="fieldDescription checkboxFieldDescription"> When active it sends favorite status </div>
                     </div>
 
+                    <h3>Date Filtering</h3>
+                    <div class="checkboxContainer">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="enabledatefilter" />
+                            <span>Enable Date Filtering</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription"> Only sync movies played within the specified number of days </div>
+                    </div>
+                    <div class="inputContainer">
+                        <input is="emby-input" type="number" id="datefilterdays" label="Days to look back" min="1" max="365" />
+                        <div class="fieldDescription">Number of days to look back for played movies (1-365)</div>
+                    </div>
+
                     <div>
                         <button id="save-button" is="emby-button" type="submit" class="raised button-submit block">
                             <span>${Save}</span>

--- a/LetterboxdSync/Web/configLetterboxd.js
+++ b/LetterboxdSync/Web/configLetterboxd.js
@@ -25,6 +25,8 @@ export default function (view, params) {
                 view.querySelector('#password').value = configUserFilter[0].PasswordLetterboxd;
                 view.querySelector('#enable').checked = configUserFilter[0].Enable;
                 view.querySelector('#sendfavorite').checked = configUserFilter[0].SendFavorite;
+                view.querySelector('#enabledatefilter').checked = configUserFilter[0].EnableDateFilter || false;
+                view.querySelector('#datefilterdays').value = configUserFilter[0].DateFilterDays || 7;
             });
         });
     });
@@ -46,12 +48,16 @@ export default function (view, params) {
                 view.querySelector('#password').value = configUserFilter[0].PasswordLetterboxd;
                 view.querySelector('#enable').checked = configUserFilter[0].Enable;
                 view.querySelector('#sendfavorite').checked = configUserFilter[0].SendFavorite;
+                view.querySelector('#enabledatefilter').checked = configUserFilter[0].EnableDateFilter || false;
+                view.querySelector('#datefilterdays').value = configUserFilter[0].DateFilterDays || 7;
             }
             else {
                 view.querySelector('#username').value = '';
                 view.querySelector('#password').value = '';
                 view.querySelector('#enable').checked = false;
                 view.querySelector('#sendfavorite').checked = false;
+                view.querySelector('#enabledatefilter').checked = false;
+                view.querySelector('#datefilterdays').value = 7;
             }
     
         });
@@ -79,6 +85,8 @@ export default function (view, params) {
             configUser.PasswordLetterboxd = view.querySelector('#password').value;
             configUser.Enable = view.querySelector('#enable').checked;
             configUser.SendFavorite = view.querySelector('#sendfavorite').checked;
+            configUser.EnableDateFilter = view.querySelector('#enabledatefilter').checked;
+            configUser.DateFilterDays = parseInt(view.querySelector('#datefilterdays').value) || 7;
 
             const data = JSON.stringify(configUser);
             const url = ApiClient.getUrl('Jellyfin.Plugin.LetterboxdSync/Authenticate');
@@ -117,3 +125,4 @@ export default function (view, params) {
         })
     })
 }
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ https://raw.githubusercontent.com/Gizmo091/jellyfin-plugin-letterboxd-sync/maste
 
  - Check `Send Favorite` if you want films marked as favorites on Jellyfin to be marked as favorites on Letterboxd.
 
+ - By default the plugin will do a full sync to letterboxd. Once done initially its advised to `Enable Date Filtering` with a short lookback to avoid load on letterboxd.
+
 <p align="center">
     <img src="/images/config-page.png" width="70%">
 </p>


### PR DESCRIPTION
Adds an option to prune the watched films list to only include the last x days before going to the letterboxd api. This saves making thousands of requests on large libraries because we are always doing a full sync.

This:

- will ease load on letterboxd servers / make us good citizens
- be much faster to do the sync jellyfin side as only checking a small subset of films

Default is to do a full sync and doc updated to include a suggestion to switch to a shorter lookback once a full sync is done and you are in standard cadence.